### PR TITLE
Duplette metadata fix

### DIFF
--- a/kinto/schema.yml
+++ b/kinto/schema.yml
@@ -70,7 +70,8 @@ buckets:
             required: false
           cache_expires: 0
           displayFields:
-          - title
+          - key
+          - description
           id: accident_cause
           schema:
             properties:

--- a/processing/csv_.py
+++ b/processing/csv_.py
@@ -26,6 +26,10 @@ def import_csv(file_path: PathLike, file_meta: dict):
                 }
                 data_dict['key'] = int(data_dict['key'])
 
+                # 'id' is the field that is used to uniquely identify the rows so that they are inserted twice
+                # this must be a string
+                data_dict['id'] = str(data_dict['key'])
+
                 create_record(data_dict, collection=file_meta['collection'])
             except Exception as e:
                 print(


### PR DESCRIPTION
Make sure that metadata files are not inserted twice.

Refers to #23 

Includes changes from branch import-missing-as-null (#24 )